### PR TITLE
Better handling of event stream errors

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -87,7 +87,7 @@ func (c *controller) Run(ctx context.Context) error {
 				defer c.streamWaitGroup.Done()
 				err := stream.Subscribe(streamCtx, MeteredEventHandler(c.Observability.Meter, n, EventHandlerFunc(c.enqueue)))
 				if err != nil {
-					c.Error("Failed subscribing to stream", "error", err)
+					c.Error("Failed subscribing to stream", "error", err, "stream", n)
 					errChan <- err
 				}
 			}()


### PR DESCRIPTION
If an individual event stream fails, the error is not properly propagated to the reconciler.
The error is muted, and the reconciler continue to pull events from other stream without restarting or notifying the caller.